### PR TITLE
Fix duration setting for 50.000 framerate in DDVT_MKVTOMP4.cmd

### DIFF
--- a/DDVT_MKVTOMP4.cmd
+++ b/DDVT_MKVTOMP4.cmd
@@ -482,7 +482,7 @@ if "%FRAMERATE%"=="24.000" set "duration=--fps 0:24"
 if "%FRAMERATE%"=="25.000" set "duration=--fps 0:25"
 if "%FRAMERATE%"=="30.000" set "duration=--fps 0:30"
 if "%FRAMERATE%"=="48.000" set "duration=--fps 0:48"
-if "%FRAMERATE%"=="50.000" set "duration=--fps 0:35"
+if "%FRAMERATE%"=="50.000" set "duration=--fps 0:50"
 if "%FRAMERATE%"=="60.000" set "duration=--fps 0:60"
 
 IF "%AUDIOCODEC%"=="Untouched" set "AUDIOCODECC=-c:a copy" & set "DRC="


### PR DESCRIPTION
This pull request includes a correction to the `DDVT_MKVTOMP4.cmd` script. The change fixes an incorrect framerate mapping for `50.000` fps.

* **Bug Fix in Framerate Mapping**:
  - Corrected the framerate mapping for `50.000` fps in the `DDVT_MKVTOMP4.cmd` script from `--fps 0:35` to `--fps 0:50`.